### PR TITLE
fix possible block skip bug in events polling

### DIFF
--- a/src/eth-model/event-model.ts
+++ b/src/eth-model/event-model.ts
@@ -24,17 +24,17 @@ function getEventMatcher(event: EventData) {
 // TODO what happens in a re-org? should we confirm blockHash of events match block ?
 export class EventModel<T extends EventData> {
     private eventsPerBlock = new Array<EventBlockData<T>>();
-    private nextBlock = 0;
+    private topBlock = 0;
     constructor() {
         this.eventsPerBlock.push({ time: -1, blockNumber: -1, events: [] }); // invariant: this.eventsPerBlock has to be at least 1
     }
 
-    getNextBlock() {
-        return Math.max(this.nextBlock, this.eventsPerBlock[this.eventsPerBlock.length - 1].blockNumber + 1);
+    getTopBlock() {
+        return Math.max(this.topBlock, this.eventsPerBlock[this.eventsPerBlock.length - 1].blockNumber);
     }
 
-    setNextBlock(nextBlock: number) {
-        this.nextBlock = nextBlock;
+    setTopBlock(nextBlock: number) {
+        this.topBlock = nextBlock;
     }
     rememberEvent(event: T, blockTime: number) {
         for (let i = this.eventsPerBlock.length - 1; i >= 0; --i) {


### PR DESCRIPTION
I Think there might be a test bug where events at the edge of the polling range get lost because the filter's range might be exclusive in ganache (although it [should not be](https://ethereum.stackexchange.com/questions/78620/is-the-range-of-a-filterquery-inclusive-up-to-toblock)). 

since the model de-dupes events well, I suggest we overlap the query range by one block.