### PR TITLE
Consolidate regex

### DIFF
--- a/src/deployment/image-poll.test.ts
+++ b/src/deployment/image-poll.test.ts
@@ -27,7 +27,7 @@ test('getGradualRolloutDelay returns random values in window', (t) => {
 
   let sumHotfix = 0;
   for (let i = 0; i < iterations; i++) {
-    const delay = p.getGradualRolloutDelay('v1.2.3-hotfix');
+    const delay = p.getGradualRolloutDelay('foo:v1.2.3-hotfix');
     t.assert(delay >= 0);
     t.assert(delay <= 2000);
     sumHotfix += delay;
@@ -42,17 +42,17 @@ test('performImmediateUpdate does not downgrade', (t) => {
   const s = new StateManager(exampleConfig);
   const p = new ImagePoll(s, exampleConfig);
 
-  p.performImmediateUpdate('main', 'node', 'v1.0.0');
-  p.performImmediateUpdate('main', 'node', 'v1.0.0'); // if poll provides the same version
-  p.performImmediateUpdate('main', 'node', 'v2.0.0');
-  p.performImmediateUpdate('main', 'node', 'v1.8.0'); // downgrade not allowed
-  p.performImmediateUpdate('canary', 'node', 'v5.0.0');
-  p.performImmediateUpdate('canary', 'node', 'v6.0.0-4729843');
-  p.performImmediateUpdate('main', 'management-service', 'v7.0.0');
+  p.performImmediateUpdate('main', 'node', 'foo:v1.0.0');
+  p.performImmediateUpdate('main', 'node', 'foo:v1.0.0'); // if poll provides the same version
+  p.performImmediateUpdate('main', 'node', 'foo:v2.0.0');
+  p.performImmediateUpdate('main', 'node', 'foo:v1.8.0'); // downgrade not allowed
+  p.performImmediateUpdate('canary', 'node', 'foo:v5.0.0');
+  p.performImmediateUpdate('canary', 'node', 'foo:v6.0.0-4729843');
+  p.performImmediateUpdate('main', 'management-service', 'foo:v7.0.0');
 
-  t.is(s.getCurrentSnapshot().CurrentImageVersions['main']['node'], 'v2.0.0');
-  t.is(s.getCurrentSnapshot().CurrentImageVersions['main']['management-service'], 'v7.0.0');
-  t.is(s.getCurrentSnapshot().CurrentImageVersions['canary']['node'], 'v5.0.0');
+  t.is(s.getCurrentSnapshot().CurrentImageVersions['main']['node'], 'foo:v2.0.0');
+  t.is(s.getCurrentSnapshot().CurrentImageVersions['main']['management-service'], 'foo:v7.0.0');
+  t.is(s.getCurrentSnapshot().CurrentImageVersions['canary']['node'], 'foo:v5.0.0');
 });
 
 test('performGradualRollout works as expected', async (t) => {
@@ -67,52 +67,52 @@ test('performGradualRollout works as expected', async (t) => {
   s.applyNewImageVersionPollTime(0, 'main', 'node');
   s.applyNewImageVersionPollTime(0, 'canary', 'node');
 
-  p.performGradualRollout('main', 'node', 'v1.1.0');
-  p.performGradualRollout('canary', 'node', 'v1.1.0-canary');
-  t.is(s.getCurrentSnapshot().CurrentImageVersions['main']['node'], 'v1.1.0');
+  p.performGradualRollout('main', 'node', 'foo:v1.1.0');
+  p.performGradualRollout('canary', 'node', 'foo:v1.1.0-canary');
+  t.is(s.getCurrentSnapshot().CurrentImageVersions['main']['node'], 'foo:v1.1.0');
   t.is(s.getCurrentSnapshot().CurrentImageVersionsUpdater['main']['node'].PendingVersion, '');
   t.assert(s.getCurrentSnapshot().CurrentImageVersionsUpdater['main']['node'].PendingVersionTime == 0);
-  t.is(s.getCurrentSnapshot().CurrentImageVersions['canary']['node'], 'v1.1.0-canary');
+  t.is(s.getCurrentSnapshot().CurrentImageVersions['canary']['node'], 'foo:v1.1.0-canary');
   t.is(s.getCurrentSnapshot().CurrentImageVersionsUpdater['canary']['node'].PendingVersion, '');
   t.assert(s.getCurrentSnapshot().CurrentImageVersionsUpdater['canary']['node'].PendingVersionTime == 0);
 
-  p.performGradualRollout('main', 'node', 'v1.1.0'); // if poll provides the same version
-  t.is(s.getCurrentSnapshot().CurrentImageVersions['main']['node'], 'v1.1.0');
+  p.performGradualRollout('main', 'node', 'foo:v1.1.0'); // if poll provides the same version
+  t.is(s.getCurrentSnapshot().CurrentImageVersions['main']['node'], 'foo:v1.1.0');
   t.is(s.getCurrentSnapshot().CurrentImageVersionsUpdater['main']['node'].PendingVersion, '');
   t.assert(s.getCurrentSnapshot().CurrentImageVersionsUpdater['main']['node'].PendingVersionTime == 0);
 
-  p.performGradualRollout('main', 'node', 'v1.2.0');
-  t.is(s.getCurrentSnapshot().CurrentImageVersions['main']['node'], 'v1.1.0');
-  t.is(s.getCurrentSnapshot().CurrentImageVersionsUpdater['main']['node'].PendingVersion, 'v1.2.0');
+  p.performGradualRollout('main', 'node', 'foo:v1.2.0');
+  t.is(s.getCurrentSnapshot().CurrentImageVersions['main']['node'], 'foo:v1.1.0');
+  t.is(s.getCurrentSnapshot().CurrentImageVersionsUpdater['main']['node'].PendingVersion, 'foo:v1.2.0');
   t.assert(s.getCurrentSnapshot().CurrentImageVersionsUpdater['main']['node'].PendingVersionTime > 1400000000);
 
-  p.performGradualRollout('main', 'node', 'v1.3.0');
-  t.is(s.getCurrentSnapshot().CurrentImageVersions['main']['node'], 'v1.1.0');
-  t.is(s.getCurrentSnapshot().CurrentImageVersionsUpdater['main']['node'].PendingVersion, 'v1.3.0');
+  p.performGradualRollout('main', 'node', 'foo:v1.3.0');
+  t.is(s.getCurrentSnapshot().CurrentImageVersions['main']['node'], 'foo:v1.1.0');
+  t.is(s.getCurrentSnapshot().CurrentImageVersionsUpdater['main']['node'].PendingVersion, 'foo:v1.3.0');
   t.assert(s.getCurrentSnapshot().CurrentImageVersionsUpdater['main']['node'].PendingVersionTime > 1400000000);
 
-  p.performGradualRollout('main', 'node', 'v1.2.0'); // downgrade not allowed
-  t.is(s.getCurrentSnapshot().CurrentImageVersions['main']['node'], 'v1.1.0');
-  t.is(s.getCurrentSnapshot().CurrentImageVersionsUpdater['main']['node'].PendingVersion, 'v1.3.0');
+  p.performGradualRollout('main', 'node', 'foo:v1.2.0'); // downgrade not allowed
+  t.is(s.getCurrentSnapshot().CurrentImageVersions['main']['node'], 'foo:v1.1.0');
+  t.is(s.getCurrentSnapshot().CurrentImageVersionsUpdater['main']['node'].PendingVersion, 'foo:v1.3.0');
   t.assert(s.getCurrentSnapshot().CurrentImageVersionsUpdater['main']['node'].PendingVersionTime > 1400000000);
 
-  p.performGradualRollout('main', 'node', 'v1.2.1-immediate'); // downgrade not allowed
-  t.is(s.getCurrentSnapshot().CurrentImageVersions['main']['node'], 'v1.1.0');
-  t.is(s.getCurrentSnapshot().CurrentImageVersionsUpdater['main']['node'].PendingVersion, 'v1.3.0');
+  p.performGradualRollout('main', 'node', 'foo:v1.2.1-immediate'); // downgrade not allowed
+  t.is(s.getCurrentSnapshot().CurrentImageVersions['main']['node'], 'foo:v1.1.0');
+  t.is(s.getCurrentSnapshot().CurrentImageVersionsUpdater['main']['node'].PendingVersion, 'foo:v1.3.0');
   t.assert(s.getCurrentSnapshot().CurrentImageVersionsUpdater['main']['node'].PendingVersionTime > 1400000000);
 
-  p.performGradualRollout('main', 'node', 'v1.3.1-immediate');
-  t.is(s.getCurrentSnapshot().CurrentImageVersions['main']['node'], 'v1.3.1-immediate');
+  p.performGradualRollout('main', 'node', 'foo:v1.3.1-immediate');
+  t.is(s.getCurrentSnapshot().CurrentImageVersions['main']['node'], 'foo:v1.3.1-immediate');
   t.is(s.getCurrentSnapshot().CurrentImageVersionsUpdater['main']['node'].PendingVersion, '');
   t.assert(s.getCurrentSnapshot().CurrentImageVersionsUpdater['main']['node'].PendingVersionTime == 0);
 
-  p.performGradualRollout('main', 'node', 'v1.4.0-hotfix');
-  p.performGradualRollout('canary', 'node', 'v1.4.0-canary-hotfix');
+  p.performGradualRollout('main', 'node', 'foo:v1.4.0-hotfix');
+  p.performGradualRollout('canary', 'node', 'foo:v1.4.0-canary-hotfix');
   await sleep(3000);
-  t.is(s.getCurrentSnapshot().CurrentImageVersions['main']['node'], 'v1.4.0-hotfix');
+  t.is(s.getCurrentSnapshot().CurrentImageVersions['main']['node'], 'foo:v1.4.0-hotfix');
   t.is(s.getCurrentSnapshot().CurrentImageVersionsUpdater['main']['node'].PendingVersion, '');
   t.assert(s.getCurrentSnapshot().CurrentImageVersionsUpdater['main']['node'].PendingVersionTime == 0);
-  t.is(s.getCurrentSnapshot().CurrentImageVersions['canary']['node'], 'v1.4.0-canary-hotfix');
+  t.is(s.getCurrentSnapshot().CurrentImageVersions['canary']['node'], 'foo:v1.4.0-canary-hotfix');
   t.is(s.getCurrentSnapshot().CurrentImageVersionsUpdater['canary']['node'].PendingVersion, '');
   t.assert(s.getCurrentSnapshot().CurrentImageVersionsUpdater['canary']['node'].PendingVersionTime == 0);
 });

--- a/src/deployment/versioning.test.ts
+++ b/src/deployment/versioning.test.ts
@@ -12,15 +12,24 @@ test('isValid returns true on valid versions', (t) => {
     'myhub.com/myorg/node:v0.0.0-immediate',
     'myhub.com/myorg/node:v1.22.333-immediate',
     'myhub.com/myorg/node:v0.0.0-canary-immediate',
-    'v0.0.0',
-    'v1.22.333',
-    'v0.0.0-canary',
-    'v0.0.0-hotfix',
-    'v1.22.333-hotfix',
-    'v0.0.0-canary-hotfix',
-    'v0.0.0-immediate',
-    'v1.22.333-immediate',
-    'v0.0.0-canary-immediate',
+    'foo:999/bar:v0.0.0',
+    'foo:999/bar:v1.22.333',
+    'foo:999/bar:v0.0.0-canary',
+    'foo:999/bar:v0.0.0-hotfix',
+    'foo:999/bar:v1.22.333-hotfix',
+    'foo:999/bar:v0.0.0-canary-hotfix',
+    'foo:999/bar:v0.0.0-immediate',
+    'foo/bar:v1.22.333-immediate',
+    'foo/bar:v0.0.0-canary-immediate',
+    'a:v0.0.0',
+    'a:v1.22.333',
+    'a:v0.0.0-canary',
+    'a:v0.0.0-hotfix',
+    'a:v1.22.333-hotfix',
+    'a:v0.0.0-canary-hotfix',
+    'a:v0.0.0-immediate',
+    'a:v1.22.333-immediate',
+    'a:v0.0.0-canary-immediate',
   ];
   for (const tag of validTags) {
     t.true(isValid(tag), tag);
@@ -28,14 +37,14 @@ test('isValid returns true on valid versions', (t) => {
 });
 
 test('isHotfix returns true on valid versions', (t) => {
-  const validTags = ['v0.0.0-hotfix', 'v1.22.333-hotfix', 'v0.0.0-canary-hotfix'];
+  const validTags = ['a:v0.0.0-hotfix', 'a:v1.22.333-hotfix', 'a:v0.0.0-canary-hotfix'];
   for (const tag of validTags) {
     t.true(isHotfix(tag), tag);
   }
 });
 
 test('isImmediate returns true on valid versions', (t) => {
-  const validTags = ['v0.0.0-immediate', 'v1.22.333-immediate', 'v0.0.0-canary-immediate'];
+  const validTags = ['a:v0.0.0-immediate', 'a:v1.22.333-immediate', 'a:v0.0.0-canary-immediate'];
   for (const tag of validTags) {
     t.true(isImmediate(tag), tag);
   }
@@ -60,6 +69,23 @@ test('isValid returns false on invalid versions', (t) => {
     'v1.2.3-immediate-hotfix',
     'v1.2.3-hotfix-hotfix',
     'v1.2.3-immediate-immediate',
+    'foo:999/bar:G-0-H',
+    'foo:999/bar:C-0-N',
+    'foo:999/bar:0.0.0',
+    'foo:999/bar:v0.0.0 foo',
+    'foo:999/bar:foo v0.0.0',
+    'foo:999/bar:v0.0',
+    'foo:999/bar:v0.0.',
+    'foo:999/bar:v0.0.0 -canary',
+    'foo:999/bar:v0.0.0-canar y',
+    'foo:999/bar:v01.22.333',
+    'foo:999/bar:v0.0.0-ferrary',
+    'foo:999/bar:v0.0.0-ferrary+slow',
+    'foo:999/bar:v1.3.13-cc1cc788',
+    'foo:999/bar:v1.2.3-hotfix-immediate',
+    'foo:999/bar:v1.2.3-immediate-hotfix',
+    'foo:999/bar:v1.2.3-hotfix-hotfix',
+    'foo:999/bar:v1.2.3-immediate-immediate',
   ];
   for (const tag of invalidTags) {
     t.false(isValid(tag), tag);
@@ -124,47 +150,43 @@ test('isImmediate returns false on invalid versions', (t) => {
 
 test('compare sorts the latest version at the smallest index', (t) => {
   const validTags = [
-    'v1.1.4-canary',
+    'a:v1.1.4-canary',
     'myhub.com/myorg/node:v1.0.6-canary-hotfix',
-    'v0.0.8',
-    'v0.0.11',
+    'a:v0.0.8',
+    'a:v0.0.11',
     'myhub.com/myorg/node:v0.0.1-hotfix',
-    'v0.0.0',
-    '',
-    'v0.2.5',
-    'v0.2.3-immediate',
-    'v1.0.0',
+    'a:v0.0.0',
+    'a:v0.2.5',
+    'a:v0.2.3-immediate',
+    'a:v1.0.0',
     'myhub.com/myorg/node:v1.1.3',
-    'v0.20.0-hotfix',
-    '',
-    'v0.2.0-canary',
-    'v1.11.0',
-    'v1.1.0',
+    'a:v0.20.0-hotfix',
+    'a:v0.2.0-canary',
+    'a:v1.11.0',
+    'a:v1.1.0',
   ];
   const sorted = validTags.sort(compare);
   t.deepEqual(sorted, [
-    '',
-    '',
-    'v0.0.0',
+    'a:v0.0.0',
     'myhub.com/myorg/node:v0.0.1-hotfix',
-    'v0.0.8',
-    'v0.0.11',
-    'v0.2.0-canary',
-    'v0.2.3-immediate',
-    'v0.2.5',
-    'v0.20.0-hotfix',
-    'v1.0.0',
+    'a:v0.0.8',
+    'a:v0.0.11',
+    'a:v0.2.0-canary',
+    'a:v0.2.3-immediate',
+    'a:v0.2.5',
+    'a:v0.20.0-hotfix',
+    'a:v1.0.0',
     'myhub.com/myorg/node:v1.0.6-canary-hotfix',
-    'v1.1.0',
+    'a:v1.1.0',
     'myhub.com/myorg/node:v1.1.3',
-    'v1.1.4-canary',
-    'v1.11.0',
+    'a:v1.1.4-canary',
+    'a:v1.11.0',
   ]);
 });
 test('regression sort', (t) => {
-  const validTags = ['myhub.com/myorg/node:v1.3.11', 'v1.3.9', 'v1.3.13'];
+  const validTags = ['a:myhub.com/myorg/node:v1.3.11', 'a:v1.3.9', 'a:v1.3.13'];
   const sorted = validTags.sort(compare);
-  t.deepEqual(sorted, ['v1.3.9', 'myhub.com/myorg/node:v1.3.11', 'v1.3.13']);
+  t.deepEqual(sorted, ['a:v1.3.9', 'a:myhub.com/myorg/node:v1.3.11', 'a:v1.3.13']);
 });
 
 test('can parse image name from the tag', (t) => {

--- a/src/deployment/versioning.ts
+++ b/src/deployment/versioning.ts
@@ -30,62 +30,64 @@ The v prefix is mandatory and has to be lower case.
 
 regex reference : // https://regex101.com/r/Ly7O1x/310
 */
-
-const REGULAR_EXPRESSION = /v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-canary)?(-hotfix|-immediate)?$/m;
-const HOTFIX_REGULAR_EXPRESSION = /v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-canary)?-hotfix$/m;
-const IMMEDIATE_REGULAR_EXPRESSION = /v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-canary)?-immediate$/m;
+const FULL_REGULAR_EXPRESSION =
+  /(?<imageName>.+):(?<tag>v(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(-(?<deploymentSubset>canary))?(-(?<rolloutWindow>hotfix|immediate))?)$/m;
 
 // TODO check that the image name part is well formed, not just the tag
 export function isValid(src: string): boolean {
-  const result = REGULAR_EXPRESSION.exec(src);
-  if (!result) {
-    return false;
-  }
-
-  if (result.index === 0) {
-    return true;
-  }
-
-  return src.charAt(result.index - 1) === ':'; // the legal delimiter between image and tag
+  return FULL_REGULAR_EXPRESSION.test(src);
 }
 
 export function isHotfix(src: string): boolean {
-  return HOTFIX_REGULAR_EXPRESSION.test(src);
+  const parsed: any = FULL_REGULAR_EXPRESSION.exec(src);
+  if (!parsed) {
+    return false;
+  }
+  return parsed.groups['rolloutWindow'] === 'hotfix';
+}
+
+export function isCanary(src: string): boolean {
+  const parsed: any = FULL_REGULAR_EXPRESSION.exec(src);
+  if (!parsed) {
+    return false;
+  }
+  return parsed.groups['deploymentSubset'] === 'canary';
 }
 
 export function isImmediate(src: string): boolean {
-  return IMMEDIATE_REGULAR_EXPRESSION.test(src);
+  const parsed: any = FULL_REGULAR_EXPRESSION.exec(src);
+  if (!parsed) {
+    return false;
+  }
+  return parsed.groups['rolloutWindow'] === 'immediate';
 }
 
 export function parseImageTag(src: string): undefined | { Image: string; Tag: string } {
-  if (!src) return undefined;
-
-  const result = REGULAR_EXPRESSION.exec(src);
-  if (!result) return undefined;
-
-  if (result.index < 2) return undefined; // no image name part
-
-  if (src.charAt(result.index - 1) != ':') return undefined; // TODO verify separator using reg. exp.
+  const parsed: any = FULL_REGULAR_EXPRESSION.exec(src);
+  if (!parsed) return undefined;
 
   return {
-    Image: src.slice(0, result.index - 1), // TODO match image name using named group in reg. exp.
-    Tag: src.slice(result.index),
+    Image: parsed.groups['imageName'],
+    Tag: parsed.groups['tag'],
   };
 }
 
 export function compare(a: string, b: string): number {
-  const aResult = REGULAR_EXPRESSION.exec(a);
+  const aResult: any = FULL_REGULAR_EXPRESSION.exec(a);
   if (!aResult) {
     return -1;
   }
-  const bResult = REGULAR_EXPRESSION.exec(b);
+  const bResult: any = FULL_REGULAR_EXPRESSION.exec(b);
   if (!bResult) {
     return 1;
   }
-  for (let i = 1; i <= 3; ++i) {
-    if (aResult[i] === bResult[i]) {
+  const aNumbers = [aResult.groups.major, aResult.groups.minor, aResult.groups.patch].map((n) => Number(n));
+  const bNumbers = [bResult.groups.major, bResult.groups.minor, bResult.groups.patch].map((n) => Number(n));
+
+  for (let i = 0; i < 3; i++) {
+    if (aNumbers[i] === bNumbers[i]) {
       continue;
-    } else if (Number(aResult[i]) > Number(bResult[i])) {
+    } else if (aNumbers[i] > bNumbers[i]) {
       return 1;
     } else {
       return -1;


### PR DESCRIPTION
This PR has ZERO functional benefit. It reorganizes version parsing of all elements of the image name into one regular expression.

Moreover, in the future, we plan to rely less and less on  overloading  rollout directives and version number on the image name so the relevant code may be thrown away in the next 6 months. 

*** branched off from `deployment_manifest` review only after merging #86 

LOW PRIORITY 