### PR TITLE
no more compressing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17993,11 +17993,6 @@
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
       "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
     },
-    "node-gzip": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/node-gzip/-/node-gzip-1.1.2.tgz",
-      "integrity": "sha512-ZB6zWpfZHGtxZnPMrJSKHVPrRjURoUzaDbLFj3VO70mpLTW5np96vXyHwft4Id0o+PYIzgDkBUjIzaNHhQ8srw=="
-    },
     "node-version": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/node-version/-/node-version-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "express": "^4.17.1",
     "lodash": "^4.17.21",
     "node-fetch": "^2.6.0",
-    "node-gzip": "^1.1.2",
     "p-throttle": "^3.1.0",
     "validate.js": "^0.13.1",
     "web3": "1.2.6",

--- a/src/status-writer.ts
+++ b/src/status-writer.ts
@@ -1,6 +1,5 @@
 import { mkdirSync, writeFileSync } from 'fs';
 import { dirname } from 'path';
-import { gzip } from 'node-gzip';
 import { StateManager } from './model/manager';
 import { ServiceConfiguration } from './config';
 import { renderServiceStatus, renderServiceStatusAnalytics } from './api/render-status';
@@ -20,7 +19,6 @@ export class StatusWriter {
     // do the actual writing to local files
     writeFile(this.config.StatusJsonPath, status);
     writeFile(this.config.StatusAnalyticsJsonPath, statusAnalytics);
-    await writeFileCompress(this.config.StatusAnalyticsJsonGzipPath, statusAnalytics);
 
     await sleep(0); // for eslint
   }
@@ -33,15 +31,6 @@ function writeFile(filePath: string, jsonObject: any) {
   writeFileSync(filePath, content);
   // log progress
   Logger.log(`Wrote status JSON to ${filePath} (${content.length} bytes).`);
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function writeFileCompress(filePath: string, jsonObject: any) {
-  ensureFileDirectoryExists(filePath);
-  const content = await gzip(JSON.stringify(jsonObject, null, 2));
-  writeFileSync(filePath, content);
-  // log progress
-  Logger.log(`Wrote status JSON compressed to ${filePath} (${content.length} bytes).`);
 }
 
 export function ensureFileDirectoryExists(filePath: string) {


### PR DESCRIPTION
In the past we wrote two versions of the analytics file to disk (several MB file) - one in clear text and one zipped. since adding support for compression at the HTTP layer we no longer need the compressed file, moreover, CPU usage is becoming an issue.

The compressed file version is now discontinued assuming no one is accessing the zipped file and that all access is through the main endpoint (compression is supported on the transport level)
