### PR TITLE
Support passing required config values via environment variables

### DIFF
--- a/src/cli-args.test.ts
+++ b/src/cli-args.test.ts
@@ -3,7 +3,18 @@ import { parseArgs } from './cli-args';
 import mock from 'mock-fs';
 import { ServiceConfiguration, validateServiceConfiguration } from './config';
 
+let env: NodeJS.ProcessEnv;
+
+test.before(() => {
+  env = process.env;
+});
+
+test.beforeEach(() => {
+  process.env = { ...env };
+});
+
 test.serial.afterEach.always(() => {
+  process.env = env;
   mock.restore();
 });
 
@@ -42,7 +53,45 @@ const expectedConfigValue: ServiceConfiguration = {
   ExternalLaunchConfig: inputConfigValue,
 };
 
-test.serial('parseOptions with file', (t) => {
+test('parseOptions with no file', (t) => {
+  t.throws(() => parseArgs(['--config', configPath]));
+});
+
+test('parseOptions with no config and no environment variables', (t) => {
+  t.throws(() => parseArgs([]));
+});
+
+test('parseOptions: environment variables and no config', (t) => {
+  const mockEthereumEndpoint = 'https://mainnet.infura.io/v3/1234567890';
+  const mockNodeAddress = '0x1234567890';
+  process.env.ETHEREUM_ENDPOINT = mockEthereumEndpoint;
+  process.env.NODE_ADDRESS = mockNodeAddress;
+
+  const output = parseArgs([]);
+
+  t.assert((output.ExternalLaunchConfig = {}));
+  t.assert((output.StatusJsonPath = './status/status.json'));
+  t.assert((output.EthereumEndpoint = mockEthereumEndpoint));
+  t.assert((output['node-address'] = mockNodeAddress));
+});
+
+test('parseOptions: env vars take precedence', (t) => {
+  const mockEthereumEndpoint = 'https://mainnet.infura.io/v3/1234567890';
+  const mockNodeAddress = '0x1234567890';
+  process.env.ETHEREUM_ENDPOINT = mockEthereumEndpoint;
+  process.env.NODE_ADDRESS = mockNodeAddress;
+
+  mock({
+    [configPath]: JSON.stringify(inputConfigValue),
+  });
+
+  const output = parseArgs(['--config', configPath]);
+
+  t.assert((output.EthereumEndpoint = mockEthereumEndpoint));
+  t.assert((output['node-address'] = mockNodeAddress));
+});
+
+test('parseOptions with file', (t) => {
   mock({
     [configPath]: JSON.stringify(inputConfigValue),
   });
@@ -50,19 +99,11 @@ test.serial('parseOptions with file', (t) => {
   t.deepEqual(parseArgs(['--config', configPath]), expectedConfigValue);
 });
 
-test.serial('parseOptions with partial file (complete default values)', (t) => {
+test('parseOptions with partial file (complete default values)', (t) => {
   mock({
     [configPath]: JSON.stringify(minimalConfigValue),
   });
 
   const options = parseArgs(['--config', configPath]);
   t.deepEqual(validateServiceConfiguration(options), undefined);
-});
-
-test.serial('parseOptions with no file', (t) => {
-  t.throws(() => parseArgs(['--config', configPath]));
-});
-
-test.serial('parseOptions with no config', (t) => {
-  t.throws(() => parseArgs([]));
 });

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -1,4 +1,4 @@
-import { ServiceConfiguration, validateServiceConfiguration, defaultServiceConfiguration } from './config';
+import { ServiceConfiguration, defaultServiceConfiguration, validateServiceConfiguration } from './config';
 import { readFileSync } from 'fs';
 import yargs from 'yargs';
 import * as Logger from './logger';
@@ -7,19 +7,23 @@ export function parseArgs(argv: string[]): ServiceConfiguration {
   const options = yargs(argv)
     .option('config', {
       type: 'array',
-      required: true,
       string: true,
       description: 'list of config files',
     })
     .exitProcess(false)
     .parse();
 
+  // If config.json not provided, required config values must be passed via environment variables
   const externalLaunchConfig = Object.assign(
     {},
-    ...options.config.map((configFile) => JSON.parse(readFileSync(configFile).toString()))
+    ...(options.config ?? []).map((configFile) => JSON.parse(readFileSync(configFile).toString()))
   );
 
-  const config = Object.assign(defaultServiceConfiguration, externalLaunchConfig);
+  const config: ServiceConfiguration = Object.assign(defaultServiceConfiguration, externalLaunchConfig);
+
+  // Support passing required config values via environment variables
+  config.EthereumEndpoint = process.env.ETHEREUM_ENDPOINT ?? config.EthereumEndpoint;
+  config['node-address'] = process.env.NODE_ADDRESS ?? config['node-address'];
 
   config.ExternalLaunchConfig = externalLaunchConfig;
 


### PR DESCRIPTION
## What's this?
Support passing required config values via environment variables (needed for v3 architecture), in addition to config file.

## Testing

### Unit tests
Run `npx ava --verbose --timeout=10m --serial --fail-fast src/cli-args.test.ts `

### Running locally
#### No config file and no environment variables
1. Run `npx tsc --skipLibCheck -p ./tsconfig.prod.json && npm run start`

#### Environment variables and no config file
1.  Add the following env vars:
```
export ETHEREUM_ENDPOINT=https://mainnet.infura.io/v3/123
export NODE_ADDRESS=55555555d4bbbe34b470f12cb0e2cd2387f6710ec5815733005bc887c317e8cf
```
2. Run `npx tsc --skipLibCheck -p ./tsconfig.prod.json && npm run start`

#### Config file and no environment variables
1. Ensure previous env vars are not set:
```
unset ETHEREUM_ENDPOINT
unset NODE_ADDRESS
```
2. Create `config.json` in root of project with following:
```
{
  "EthereumEndpoint": "https://mainnet.infura.io/v3/123",
  "MaticEndpoint": "https://polygon-mainnet.g.alchemy.com/v2/123",
  "node-address": "55555555d4bbbe34b470f12cb0e2cd2387f6710ec5815733005bc887c317e8cf"
}
```
3. Run `npx tsc --skipLibCheck -p ./tsconfig.prod.json && npm run start -- --config ./config.json`
