### PR TITLE
Support passing required config values via environment variables

### DIFF
--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -1,27 +1,32 @@
-import { ServiceConfiguration, validateServiceConfiguration, defaultServiceConfiguration } from './config';
+import { ServiceConfiguration, defaultServiceConfiguration, validateServiceConfiguration } from './config';
 import { readFileSync } from 'fs';
 import yargs from 'yargs';
 import * as Logger from './logger';
+
+import { setConfigEnvVars } from './env-var-args';
 
 export function parseArgs(argv: string[]): ServiceConfiguration {
   const options = yargs(argv)
     .option('config', {
       type: 'array',
-      required: true,
       string: true,
       description: 'list of config files',
     })
     .exitProcess(false)
     .parse();
 
+  // If config.json not provided, required config values must be passed via environment variables
   const externalLaunchConfig = Object.assign(
     {},
-    ...options.config.map((configFile) => JSON.parse(readFileSync(configFile).toString()))
+    ...(options.config ?? []).map((configFile) => JSON.parse(readFileSync(configFile).toString()))
   );
 
-  const config = Object.assign(defaultServiceConfiguration, externalLaunchConfig);
+  const config: ServiceConfiguration = Object.assign(defaultServiceConfiguration, externalLaunchConfig);
 
   config.ExternalLaunchConfig = externalLaunchConfig;
+
+  // Support passing required config values via environment variables
+  setConfigEnvVars(config);
 
   const validationErrors = validateServiceConfiguration(config);
   if (validationErrors) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,7 @@ export interface ServiceConfiguration {
   Port: number;
   EthereumGenesisContract: string;
   EthereumEndpoint: string;
+  /** @deprecated Use `EthereumEndpoint` instead */
   MaticEndpoint?: string;
   DeploymentDescriptorUrl: string;
   ElectionsAuditOnly: boolean;

--- a/src/env-var-args.test.ts
+++ b/src/env-var-args.test.ts
@@ -1,0 +1,99 @@
+import test from 'ava';
+import { exampleConfig } from './config.example';
+import { setConfigEnvVars } from './env-var-args';
+import { ServiceConfiguration } from './config';
+
+test('setConfigEnvVars uses default values when no environment variables', (t) => {
+  const input = { ...exampleConfig };
+  setConfigEnvVars(input);
+  t.deepEqual(input, exampleConfig);
+});
+
+/**
+ * Converts mockEnv property names to Configuration names
+ * Eg. ETHEREUM_ENDPOINT -> EthereumEndpoint
+ * */
+const camelCaseToSnakeCase = (str: string): string => {
+  const result = str.replace(/([a-z])([A-Z])/g, '$1_$2');
+  return result.toUpperCase();
+};
+
+const mockEnv = {
+  BOOTSTRAP_MODE: false,
+  PORT: 8080,
+  ETHEREUM_GENESIS_CONTRACT: '0x1234567890',
+  ETHEREUM_ENDPOINT: 'https://mainnet.infura.io/v3/1234567890',
+  MATIC_ENDPOINT: 'https://polygon-rpc.com/',
+  DEPLOYMENT_DESCRIPTOR_URL: 'http://localhost/deployment.json',
+  ELECTIONS_AUDIT_ONLY: false,
+  STATUS_JSON_PATH: '/path/to/status.json',
+  STATUS_ANALYTICS_JSON_PATH: '/path/to/analytics.json',
+  STATUS_ANALYTICS_JSON_GZIP_PATH: '/path/to/gzip.json',
+  STATUS_WRITE_INTERVAL_SECONDS: 60,
+  DEPLOYMENT_DESCRIPTOR_POLL_INTERVAL_SECONDS: 120,
+  REGULAR_ROLLOUT_WINDOW_SECONDS: 180,
+  HOTFIX_ROLLOUT_WINDOW_SECONDS: 240,
+  ETHEREUM_POLL_INTERVAL_SECONDS: 300,
+  ETHEREUM_REQUESTS_PER_SECOND_LIMIT: 10,
+  ELECTIONS_STALE_UPDATE_SECONDS: 360,
+  FINALITY_BUFFER_BLOCKS: 12,
+  ETHEREUM_FIRST_BLOCK: 123456,
+  VERBOSE: false,
+  NODE_ADDRESS: '555550a3c12e86b4b5f39b213f7e19d048276dae',
+  EXTERNAL_LAUNCH_CONFIG: '{"key": "value"}',
+};
+
+test('setConfigEnvVars uses environment variables when set', (t) => {
+  const input: ServiceConfiguration = { ...exampleConfig };
+
+  // Need to cast to stop TS complaining about number/string mismatch
+  process.env = { ...process.env, ...mockEnv } as unknown as NodeJS.ProcessEnv;
+
+  setConfigEnvVars(input);
+
+  for (const key of Object.keys(exampleConfig)) {
+    // Handle `node-address` and `ExternalLaunchConfig` as they are parsed differently
+    if (key === 'node-address') {
+      t.assert(input[key as keyof ServiceConfiguration] === mockEnv.NODE_ADDRESS);
+      continue;
+    }
+
+    if (key === 'ExternalLaunchConfig') {
+      t.deepEqual(input[key as keyof ServiceConfiguration], JSON.parse(mockEnv.EXTERNAL_LAUNCH_CONFIG));
+      continue;
+    }
+
+    t.assert(input[key as keyof ServiceConfiguration] === mockEnv[camelCaseToSnakeCase(key) as keyof typeof mockEnv]);
+  }
+});
+
+test('boolean environment variables are parsed correctly', (t) => {
+  const input: ServiceConfiguration = { ...exampleConfig };
+
+  const testCases = [
+    { description: 'No env var set, should use default', envVar: undefined, expected: input.BootstrapMode },
+    { description: 'Env var set to `true`, should resolve to true', envVar: 'true', expected: true },
+    { description: 'Env var set to `false`, should resolve to false', envVar: 'false', expected: false },
+  ];
+
+  for (const testCase of testCases) {
+    process.env.BOOTSTRAP_MODE = testCase.envVar;
+    setConfigEnvVars(input);
+    t.assert(input.BootstrapMode === testCase.expected, testCase.description);
+  }
+});
+
+test('number environment variables are parsed correctly', (t) => {
+  const input: ServiceConfiguration = { ...exampleConfig };
+
+  const testCases = [
+    { description: 'No env var set, should use default', envVar: undefined, expected: input.Port },
+    { description: 'Env var set to `8082`, should resolve to 8082', envVar: '8082', expected: 8082 },
+  ];
+
+  for (const testCase of testCases) {
+    process.env.PORT = testCase.envVar;
+    setConfigEnvVars(input);
+    t.assert(input.Port === testCase.expected, testCase.description);
+  }
+});

--- a/src/env-var-args.ts
+++ b/src/env-var-args.ts
@@ -1,0 +1,56 @@
+import { ServiceConfiguration } from './config';
+
+/**
+ * Parse required and optional node configuration from environment variables
+ *
+ * Environment variables override default configuration values
+ *
+ * Validation handled later in `validateServiceConfiguration`
+ * @param config - The node configuration to update
+ * */
+export function setConfigEnvVars(config: ServiceConfiguration): void {
+  config.BootstrapMode = process.env.BOOTSTRAP_MODE ? process.env.BOOTSTRAP_MODE === 'true' : config.BootstrapMode;
+  config.Port = process.env.PORT ? Number(process.env.PORT) : config.Port;
+  config.EthereumGenesisContract = process.env.ETHEREUM_GENESIS_CONTRACT ?? config.EthereumGenesisContract;
+  config.EthereumEndpoint = process.env.ETHEREUM_ENDPOINT ?? config.EthereumEndpoint;
+  config.DeploymentDescriptorUrl = process.env.DEPLOYMENT_DESCRIPTOR_URL ?? config.DeploymentDescriptorUrl;
+  config.ElectionsAuditOnly = process.env.ELECTIONS_AUDIT_ONLY
+    ? process.env.ELECTIONS_AUDIT_ONLY === 'true'
+    : config.ElectionsAuditOnly;
+  config.StatusJsonPath = process.env.STATUS_JSON_PATH ?? config.StatusJsonPath;
+  config.StatusAnalyticsJsonPath = process.env.STATUS_ANALYTICS_JSON_PATH ?? config.StatusAnalyticsJsonPath;
+  config.StatusAnalyticsJsonGzipPath =
+    process.env.STATUS_ANALYTICS_JSON_GZIP_PATH ?? config.StatusAnalyticsJsonGzipPath;
+  config.StatusWriteIntervalSeconds = process.env.STATUS_WRITE_INTERVAL_SECONDS
+    ? Number(process.env.STATUS_WRITE_INTERVAL_SECONDS)
+    : config.StatusWriteIntervalSeconds;
+  config.DeploymentDescriptorPollIntervalSeconds = process.env.DEPLOYMENT_DESCRIPTOR_POLL_INTERVAL_SECONDS
+    ? Number(process.env.DEPLOYMENT_DESCRIPTOR_POLL_INTERVAL_SECONDS)
+    : config.DeploymentDescriptorPollIntervalSeconds;
+  config.RegularRolloutWindowSeconds = process.env.REGULAR_ROLLOUT_WINDOW_SECONDS
+    ? Number(process.env.REGULAR_ROLLOUT_WINDOW_SECONDS)
+    : config.RegularRolloutWindowSeconds;
+  config.HotfixRolloutWindowSeconds = process.env.HOTFIX_ROLLOUT_WINDOW_SECONDS
+    ? Number(process.env.HOTFIX_ROLLOUT_WINDOW_SECONDS)
+    : config.HotfixRolloutWindowSeconds;
+  config.EthereumPollIntervalSeconds = process.env.ETHEREUM_POLL_INTERVAL_SECONDS
+    ? Number(process.env.ETHEREUM_POLL_INTERVAL_SECONDS)
+    : config.EthereumPollIntervalSeconds;
+  config.EthereumRequestsPerSecondLimit = process.env.ETHEREUM_REQUESTS_PER_SECOND_LIMIT
+    ? Number(process.env.ETHEREUM_REQUESTS_PER_SECOND_LIMIT)
+    : config.EthereumRequestsPerSecondLimit;
+  config.ElectionsStaleUpdateSeconds = process.env.ELECTIONS_STALE_UPDATE_SECONDS
+    ? Number(process.env.ELECTIONS_STALE_UPDATE_SECONDS)
+    : config.ElectionsStaleUpdateSeconds;
+  config.FinalityBufferBlocks = process.env.FINALITY_BUFFER_BLOCKS
+    ? Number(process.env.FINALITY_BUFFER_BLOCKS)
+    : config.FinalityBufferBlocks;
+  config.EthereumFirstBlock = process.env.ETHEREUM_FIRST_BLOCK
+    ? Number(process.env.ETHEREUM_FIRST_BLOCK)
+    : config.EthereumFirstBlock;
+  config.Verbose = process.env.VERBOSE ? process.env.VERBOSE === 'true' : config.Verbose;
+  config['node-address'] = process.env.NODE_ADDRESS ?? config['node-address'];
+  config.ExternalLaunchConfig = process.env.EXTERNAL_LAUNCH_CONFIG
+    ? JSON.parse(process.env.EXTERNAL_LAUNCH_CONFIG)
+    : config.ExternalLaunchConfig;
+}


### PR DESCRIPTION
## What's this?
Support passing required config values via environment variables (needed for v3 architecture), in addition to config file.

## Testing

### Unit tests
Run `npx ava --verbose --timeout=10m --serial --fail-fast src/cli-args.test.ts src/env-var-args.test.ts`

### Running locally
#### No config file and no environment variables
1. Run `npx tsc --skipLibCheck -p ./tsconfig.prod.json && npm run start`

#### Environment variables and no config file
1.  Add the following env vars:
```
export ETHEREUM_ENDPOINT=https://mainnet.infura.io/v3/123
export NODE_ADDRESS=55555555d4bbbe34b470f12cb0e2cd2387f6710ec5815733005bc887c317e8cf
```
2. Run `npx tsc --skipLibCheck -p ./tsconfig.prod.json && npm run start`

#### Config file and no environment variables
1. Ensure previous env vars are not set:
```
unset ETHEREUM_ENDPOINT
unset NODE_ADDRESS
```
2. Create `config.json` in root of project with following:
```
{
  "EthereumEndpoint": "https://mainnet.infura.io/v3/123",
  "MaticEndpoint": "https://polygon-mainnet.g.alchemy.com/v2/123",
  "node-address": "55555555d4bbbe34b470f12cb0e2cd2387f6710ec5815733005bc887c317e8cf"
}
```
3. Run `npx tsc --skipLibCheck -p ./tsconfig.prod.json && npm run start -- --config ./config.json`
